### PR TITLE
fix: made async function sync and added static ref to config and qbit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config<'a> {
     pub host: &'a str,
 }
 
-pub fn load_config(args: &Args) -> Result<Config> {
+pub fn load_config(args: Args) -> Result<Config<'static>> {
     let mut config = config::Config::builder();
 
     // /etc/qbitbot/config.toml


### PR DESCRIPTION
Now the config consumes the command line args, but it's fine because it's the only one to use them.
The config and the qbit are now a lazily initialized static references.
Still suboptimal to use static references but i wouldn't use an in memory db just for 2 variables.